### PR TITLE
fix: restore federation zone mapping after merge regression

### DIFF
--- a/pkg/metastore/federation.go
+++ b/pkg/metastore/federation.go
@@ -46,7 +46,11 @@ func (f *Federation) updatek8sCustomResource(fed *opgv1beta1.Federation) *opgv1b
 func federationFromK8sCustomResource(fed *opgv1beta1.Federation) (*Federation, error) {
 	offeredZones := make([]models.ZoneDetails, len(fed.Spec.OfferedAvailabilityZones))
 	for i, z := range fed.Spec.OfferedAvailabilityZones {
-		offeredZones[i].ZoneId = z
+		offeredZones[i] = models.ZoneDetails{
+			ZoneId:           z.ZoneId,
+			Geolocation:      z.Geolocation,
+			GeographyDetails: z.GeographyDetails,
+		}
 	}
 
 	return &Federation{


### PR DESCRIPTION
## What

Restore the correct `OfferedAvailabilityZones` mapping in `pkg/metastore/federation.go`.

## Why
Fixes #9.

A clean merge kept a stale version of `pkg/metastore/federation.go` from `main`, even though `dev-callback` was building before the merge. After that, the API code no longer matched the operator types resolved by `go.mod`, causing the build to fail at compile time.

## How

Update the federation mapping to use the fields from `ZoneDetails` (`ZoneId`, `Geolocation`, and `GeographyDetails`) instead of treating the value as a string.

## Testing

<!-- How was this verified? (unit tests, integration tests, manual testing, etc.) -->

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] No testing needed (explain why)

## Breaking Changes

<!-- List any breaking changes, or write "None" -->

None

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Each commit is a single logical change
- [x] Code compiles (`docker compose build federation`)
- [x] Tests pass (`go test ./...`)
- [x] API code regenerated if OpenAPI spec changed(`docker compose run apigen`) - **no changes generated** 
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines